### PR TITLE
feat(i18n): add Russian translations to language.cfg

### DIFF
--- a/cstrike/addons/pugmod/cfg/language.cfg
+++ b/cstrike/addons/pugmod/cfg/language.cfg
@@ -1,1266 +1,1577 @@
 // Admin
 "^4[%s]^1 You do not have access to this command."
 en:"^4[%s]^1 You do not have access to this command."
+ru:"^4[%s]^1 У вас нет доступа к этой команде."
 br:"^4[%s]^1 Você não tem acesso a esse comando."
 
 // Admin Menu
 "Pug Mod Menu:"
 en:"Pug Mod Menu:"
+ru:"Меню Pug Mod:"
 br:"Menu do Pug Mod:"
 
 "Kick Player"
 en:"Kick Player"
+ru:"Кикнуть игрока"
 br:"Kickar Jogador"
 
 "Ban Player"
 en:"Ban Player"
+ru:"Забанить игрока"
 br:"Banir Jogador"
 
 "Slap Player"
 en:"Slap Player"
+ru:"Шлепнуть игрока"
 br:"Tapa no Jogador"
 
 "Player Team"
 en:"Player Team"
+ru:"Команда игрока"
 br:"Time do Jogador"
 
 "Change Map"
 en:"Change Map"
+ru:"Сменить карту"
 br:"Mudar Mapa"
 
 "Control Pug"
 en:"Control Pug"
+ru:"Управление Pug"
 br:"Controlar Pug"
 
 "Control Cvars"
 en:"Control Cvars"
+ru:"Управление Cvars"
 br:"Controlar Cvars"
 
 "Pause Match"
 en:"Pause Match"
+ru:"Поставить матч на паузу"
 br:"Pausar Partida"
 
 "CSDM: Spawn Manager"
 en:"CSDM: Spawn Manager"
+ru:"CSDM: Менеджер спавнов"
 br:"CSDM: Spawn Manager"
 
 "Kick Player:"
 en:"Kick Player:"
+ru:"Кикнуть игрока:"
 br:"Kickar Jogador:"
 
 "^4[%s]^1 No player found."
 en:"^4[%s]^1 No player found."
+ru:"^4[%s]^1 Игрок не найден."
 br:"^4[%s]^1 Nenhum jogador encontrado."
 
 "Kicked by %s"
 en:"Kicked by %s"
+ru:"Кикнут: %s"
 br:"Kickado por %s"
 
 "Ban Player:"
 en:"Ban Player:"
+ru:"Забанить игрока:"
 br:"Banir Jogador:"
 
 "^4[%s]^1 No player found."
 en:"^4[%s]^1 No player found."
+ru:"^4[%s]^1 Игрок не найден."
 br:"^4[%s]^1 Nenhum jogador encontrado."
 
 "Ban duration: ^w%s^y"
 en:"Ban duration: ^w%s^y"
+ru:"Длительность бана: ^w%s^y"
 br:"Tempo para banir: ^w%s^y"
 
 "banid %d %s"
 en:"banid %d %s"
+ru:"banid %d %s"
 br:"banid %d %s"
 
 "wait;wait;writeid;writeip"
 en:"wait;wait;writeid;writeip"
+ru:"wait;wait;writeid;writeip"
 br:"wait;wait;writeid;writeip"
 
 "You have been banned from the server"
 en:"You have been banned from the server"
+ru:"Вы были забанены на сервере"
 br:"Você foi banido do servidor"
 
 "^4[%s]^1 No player found."
 en:"^4[%s]^1 No player found."
+ru:"^4[%s]^1 Игрок не найден."
 br:"^4[%s]^1 Nenhum jogador encontrado."
 
 "Slap Player:"
 en:"Slap Player:"
+ru:"Шлепнуть игрока:"
 br:"Tapa no Jogador:"
 
 "Slap: ^w%s^y"
 en:"Slap: ^w%s^y"
+ru:"Шлепок: ^w%s^y"
 br:"Tapa: ^w%s^y"
 
 "No Damage"
 en:"No Damage"
+ru:"Без урона"
 br:"Sem Dano"
 
 "Slap 1 HP"
 en:"Slap 1 HP"
+ru:"Шлепок на 1 HP"
 br:"Tapa 1 HP"
 
 "Slap 5 HP"
 en:"Slap 5 HP"
+ru:"Шлепок на 5 HP"
 br:"Tapa 5 HP"
 
 "Slap 10 HP"
 en:"Slap 10 HP"
+ru:"Шлепок на 10 HP"
 br:"Tapa 10 HP"
 
 "Slap 25 HP"
 en:"Slap 25 HP"
+ru:"Шлепок на 25 HP"
 br:"Tapa 25 HP"
 
 "Slap 50 HP"
 en:"Slap 50 HP"
+ru:"Шлепок на 50 HP"
 br:"Tapa 50 HP"
 
 "Kill Player"
 en:"Kill Player"
+ru:"Убить игрока"
 br:"Matar Jogador"
 
 "^4[%s]^1 No player found."
 en:"^4[%s]^1 No player found."
+ru:"^4[%s]^1 Игрок не найден."
 br:"^4[%s]^1 Nenhum jogador encontrado."
 
 "Player Team:"
 en:"Player Team:"
+ru:"Команда игрока:"
 br:"Time do Jogador:"
 
 "Transfer Team: ^w%s^y"
 en:"Transfer Team: ^w%s^y"
+ru:"Перевести в команду: ^w%s^y"
 br:"Transferir Time: ^w%s^y"
 
 "^4[%s]^1 No map found in the list."
 en:"^4[%s]^1 No map found in the list."
+ru:"^4[%s]^1 Карта не найдена в списке."
 br:"^4[%s]^1 Nenhum mapa encontrado na lista."
 
 "Change Map:"
 en:"Change Map:"
+ru:"Сменить карту:"
 br:"Mudar Mapa:"
 
 "^4[%s]^1 Changing map to: ^3%s^1."
 en:"^4[%s]^1 Changing map to: ^3%s^1."
+ru:"^4[%s]^1 Смена карты на: ^3%s^1."
 br:"^4[%s]^1 Alterando mapa para: ^3%s^1."
 
 "Choose an operation:"
 en:"Choose an operation:"
+ru:"Выберите действие:"
 br:"Escolha uma operação:"
 
 "Disable Pug" 
 en:"Disable Pug"
+ru:"Выключить Pug"
 br:"Desligar Pug"
 
 "Deathmatch"
 en:"Deathmatch"
+ru:"Deathmatch"
 br:"Deathmatch"
 
 "Map Vote"
 en:"Map Vote"
+ru:"Голосование за карту"
 br:"Votação de Mapa"
 
 "Team Vote"
 en:"Team Vote"
+ru:"Голосование за команды"
 br:"Votação de Times"
 
 "Captain Pick"
 en:"Captain Pick"
+ru:"Капитанский пик"
 br:"Escolha de Capitães"
 
 "Knife Round"
 en:"Knife Round"
+ru:"Ножевой раунд"
 br:"Round Faca"
 
 "Start Match"
 en:"Start Match"
+ru:"Начать матч"
 br:"Iniciar Partida"
 
 "Restart Match"
 en:"Restart Match"
+ru:"Перезапустить матч"
 br:"Reiniciar Partida"
 
 "Cancel Match"
 en:"Cancel Match"
+ru:"Отменить матч"
 br:"Cancelar Partida"
 
 "End Match"
 en:"End Match"
+ru:"Завершить матч"
 br:"Finalizar Partida"
 
 "^4[%s]^1 State changed: ^3%s^1."
 en:"^4[%s]^1 State changed: ^3%s^1."
+ru:"^4[%s]^1 Состояние изменено: ^3%s^1."
 br:"^4[%s]^1 Estado alterado: ^3%s^1."
 
 // Client Commands
 "*** FLOODING DETECTED ***"
 en:"*** FLOODING DETECTED ***"
+ru:"*** ОБНАРУЖЕН ФЛУД ***"
 br:"*** FLOODING DETECTADO ***"
 
 "^4[%s]^1 (^3%s^1) %s"
 en:"^4[%s]^1 (^3%s^1) %s"
+ru:"^4[%s]^1 (^3%s^1) %s"
 br:"^4[%s]^1 (^3%s^1) %s"
 
 "^4[%s]^1 Usage: ^3%s^1 <message>"
 en:"^4[%s]^1 Usage: ^3%s^1 <message>"
+ru:"^4[%s]^1 Использование: ^3%s^1 <сообщение>"
 br:"^4[%s]^1 Uso: ^3%s^1 <mensagem>"
 
 "^4[%s]^1 Command blocked."
 en:"^4[%s]^1 Command blocked."
+ru:"^4[%s]^1 Команда заблокирована."
 br:"^4[%s]^1 Comando bloqueado."
 
 "^4[%s]^1 Executed: ^3%s^1"
 en:"^4[%s]^1 Executed: ^3%s^1"
+ru:"^4[%s]^1 Выполнено: ^3%s^1"
 br:"^4[%s]^1 Executado: ^3%s^1"
 
 "^4[%s]^1 Usage: ^3%s^1 <command>"
 en:"^4[%s]^1 Usage: ^3%s^1 <command>"
+ru:"^4[%s]^1 Использование: ^3%s^1 <команда>"
 br:"^4[%s]^1 Uso: ^3%s^1 <comando>"
 
 // Cvar Control
 "Cvar Control"
 en:"Cvar Control"
+ru:"Управление cvars"
 br:"Controle de Cvars"
 
 "^4[%s]^1 %s set to: ^3%s^1"
 en:"^4[%s]^1 %s set to: ^3%s^1"
+ru:"^4[%s]^1 %s установлено в: ^3%s^1"
 br:"^4[%s]^1 %s ajustada para: ^3%s^1"
 
 // Demo Record
 "Record demo?"
 en:"Record demo?"
+ru:"Записывать демо?"
 br:"Gravar demo?"
 
 "Yes"
 en:"Yes"
+ru:"Да"
 br:"Sim"
 
 "No"
 en:"No"
+ru:"Нет"
 br:"Não"
 
 "^4[%s]^1 Recording: ^3%s^1"
 en:"^4[%s]^1 Recording: ^3%s^1"
+ru:"^4[%s]^1 Запись: ^3%s^1"
 br:"^4[%s]^1 Gravando: ^3%s^1"
  
 // Deathmatch
 "^4[%s]^1 ^3Deathmatch^1 enabled until match start."
 en:"^4[%s]^1 ^3Deathmatch^1 enabled until match start."
+ru:"^4[%s]^1 ^3Deathmatch^1 включен до начала матча."
 br:"^4[%s]^1 ^3Deathmatch^1 ativo até o início da partida."
 
 "^4[%s]^1 ^3Deathmatch^1 disabled."
 en:"^4[%s]^1 ^3Deathmatch^1 disabled."
+ru:"^4[%s]^1 ^3Deathmatch^1 выключен."
 br:"^4[%s]^1 ^3Deathmatch^1 desativado."
 
 "^4[%s]^1 The weapons menu has been enabled."
 en:"^4[%s]^1 The weapons menu has been enabled."
+ru:"^4[%s]^1 Меню оружия было включено."
 br:"^4[%s]^1 O menu de armas foi habilitado."
 
 "^4[%s]^1 The weapons menu is already enabled."
 en:"^4[%s]^1 The weapons menu is already enabled."
+ru:"^4[%s]^1 Меню оружия уже включено."
 br:"^4[%s]^1 O menu de armas já está habilitado."
 
 "KD: %.2f^nHSP: %.2f%%"
 en:"KD: %.2f^nHSP: %.2f%%"
+ru:"KD: %.2f^nHSP: %.2f%%"
 br:"KD: %.2f^nHSP: %.2f%%"
 
 "CSDM: Options"
 en:"CSDM: Options"
+ru:"CSDM: Настройки"
 br:"CSDM: Opções"
 
 "Hide Kill Feed^R%s"
 en:"Hide Kill Feed^R%s"
+ru:"Скрыть ленту убийств^R%s"
 br:"Ocultar Kill Feed^R%s"
 
 "Hit indicator^R%s"
 en:"Hit indicator^R%s"
+ru:"Индикатор попадания^R%s"
 br:"Indicador de dano^R%s"
 
 "Headshot mode^R%s"
 en:"Headshot mode^R%s"
+ru:"Режим headshot^R%s"
 br:"Modo headshot^R%s"
 
 "Show stats^R%s"
 en:"Show stats^R%s"
+ru:"Показывать статистику^R%s"
 br:"Exibir estatísticas^R%s"
 
 "Flash on kill^R%s"
 en:"Flash on kill^R%s"
+ru:"Мигать при убийстве^R%s"
 br:"Piscar ao matar^R%s"
 
 "Play sound on kill^R%s"
 en:"Play sound on kill^R%s"
+ru:"Проигрывать звук при убийстве^R%s"
 br:"Emitir som ao matar^R%s"
 
 "Show frags instead of money^R%s"
 en:"Show frags instead of money^R%s"
+ru:"Показывать фраги вместо денег^R%s"
 br:"Exibir frags no dinheiro^R%s"
 
 "CSDM: Equipment"
 en:"CSDM: Equipment"
+ru:"CSDM: Снаряжение"
 br:"CSDM: Equipamentos"
 
 "New Weapons"
 en:"New Weapons"
+ru:"Новое оружие"
 br:"Novas Armas"
 
 "Previous Setup"
 en:"Previous Setup"
+ru:"Предыдущий набор"
 br:"Setup Anterior"
 
 "2 + Hide Menu"
 en:"2 + Hide Menu"
+ru:"2 + скрыть меню"
 br:"2 + Ocultar Menu"
 
 "^4[%s]^1 Press ^3'M'^1 to view the training menu."
 en:"^4[%s]^1 Press ^3'M'^1 to view the training menu."
+ru:"^4[%s]^1 Нажмите ^3'M'^1, чтобы открыть меню тренировки."
 br:"^4[%s]^1 Tecle ^3'M'^1 para ver o menu de treino."
 
 "^4[%s]^1 Press ^3'G'^1 to view the weapons menu."
 en:"^4[%s]^1 Press ^3'G'^1 to view the weapons menu."
+ru:"^4[%s]^1 Нажмите ^3'G'^1, чтобы открыть меню оружия."
 br:"^4[%s]^1 Tecle ^3'G'^1 para ver o menu de armas."
 
 "^4[%s]^1 Press ^3'G'^1 to show the menu again."
 en:"^4[%s]^1 Press ^3'G'^1 to show the menu again."
+ru:"^4[%s]^1 Нажмите ^3'G'^1, чтобы снова показать меню."
 br:"^4[%s]^1 Tecle ^3'G'^1 para exibir o menu novamente."
 
 "CSDM: Weapons"
 en:"CSDM: Weapons"
+ru:"CSDM: Оружие"
 br:"CSDM: Armas"
 
 "^4[%s]^1 You have revived."
 en:"^4[%s]^1 You have revived."
+ru:"^4[%s]^1 Вы возродились."
 br:"^4[%s]^1 Você reviveu."
 
 "^4[%s]^1 Command unavailable."
 en:"^4[%s]^1 Command unavailable."
+ru:"^4[%s]^1 Команда недоступна."
 br:"^4[%s]^1 Comando indisponível."
 
 "^4[%s]^1 ^3%s^1 reset the score."
 en:"^4[%s]^1 ^3%s^1 reset the score."
+ru:"^4[%s]^1 ^3%s^1 сбросил счет."
 br:"^4[%s]^1 ^3%s^1 resetou o score."
 
 "^4[%s]^1 There are no frags to reset."
 en:"^4[%s]^1 There are no frags to reset."
+ru:"^4[%s]^1 Нет фрагов для сброса."
 br:"^4[%s]^1 Não há frags para resetar."
 
 // Leaders
 "^4[%s]^1 Teams are full."
 en:"^4[%s]^1 Teams are full."
+ru:"^4[%s]^1 Команды заполнены."
 br:"^4[%s]^1 Os times estão completos."
 
 "^4[%s]^1 Pick failed: Teams are incomplete.^1"
 en:"^4[%s]^1 Pick failed: Teams are incomplete.^1"
+ru:"^4[%s]^1 Выбор не удался: команды укомплектованы не полностью.^1"
 br:"^4[%s]^1 Falha ao escolher: ^3Os times estão incompletos.^1"
 
 "^4[%s]^1 New captain of ^3%s^1: %s"
 en:"^4[%s]^1 New captain of ^3%s^1: %s"
+ru:"^4[%s]^1 Новый капитан команды ^3%s^1: %s"
 br:"^4[%s]^1 Novo capitão dos ^3%s^1: %s"
 
 "^4[%s]^1 ^3%s^1 picked ^3%s^1"
 en:"^4[%s]^1 ^3%s^1 picked ^3%s^1"
+ru:"^4[%s]^1 ^3%s^1 выбрал ^3%s^1"
 br:"^4[%s]^1 ^3%s^1 escolheu ^3%s^1"
 
 "^4[%s]^1 ^3%s^1 is already on a team."
 en:"^4[%s]^1 ^3%s^1 is already on a team."
+ru:"^4[%s]^1 ^3%s^1 уже в команде."
 br:"^4[%s]^1 ^3%s^1 já está em um time."
 
 "Players:"
 en:"Players:"
+ru:"Игроки:"
 br:"Jogadores:"
 
 "^4[%s]^1 Choose a player within 10 seconds."
 en:"^4[%s]^1 Choose a player within 10 seconds."
+ru:"^4[%s]^1 Выберите игрока в течение 10 секунд."
 br:"^4[%s]^1 Escolha um jogador em 10 segundos."
 
 // LO3
 "LIVE IN THREE RESTARTS"
 en:"LIVE IN THREE RESTARTS"
+ru:"LIVE ЧЕРЕЗ ТРИ РЕСТАРТА"
 br:"VALENDO EM TRÊS RESTARTS"
 
 "LIVE IN TWO RESTARTS"
 en:"LIVE IN TWO RESTARTS"
+ru:"LIVE ЧЕРЕЗ ДВА РЕСТАРТА"
 br:"VALENDO EM DOIS RESTARTS"
 
 "LIVE ON NEXT RESTART"
 en:"LIVE ON NEXT RESTART"
+ru:"LIVE НА СЛЕДУЮЩЕМ РЕСТАРТЕ"
 br:"VALENDO NO PRÓXIMO RESTARTT"
 
 "LIVE GOOD LUCK & HAVE FUN"
 en:"LIVE GOOD LUCK & HAVE FUN"
+ru:"LIVE, УДАЧИ И ПРИЯТНОЙ ИГРЫ"
 br:"VALENDO BOA SORTE & DIVIRTA-SE"
 
 "^4[%s]^1 %s: ^3Live in three restarts!"
 en:"^4[%s]^1 %s: ^3Live in three restarts!"
+ru:"^4[%s]^1 %s: ^3Live через три рестарта!"
 br:"^4[%s]^1 %s: ^3Valendo em três restarts!"
 
 "^4[%s]^1 %s: ^3Live in two restarts!"
 en:"^4[%s]^1 %s: ^3Live in two restarts!"
+ru:"^4[%s]^1 %s: ^3Live через два рестарта!"
 br:"^4[%s]^1 %s: ^3Valendo em dois restarts!"
 
 "^4[%s]^1 %s: ^3Live on next restart!"
 en:"^4[%s]^1 %s: ^3Live on next restart!"
+ru:"^4[%s]^1 %s: ^3Live на следующем рестарте!"
 br:"^4[%s]^1 %s: ^3Valendo no próximo restart!"
 
 "^4[%s]^1 %s: ^3Live! Good Luck & Have Fun!!"
-"^4[%s]^1 %s: ^3Live! Good Luck & Have Fun!!"
+en:"^4[%s]^1 %s: ^3Live! Good Luck & Have Fun!!"
+ru:"^4[%s]^1 %s: ^3Live! Удачи и приятной игры!!"
 br:"^4[%s]^1 %s: ^3Valendo! Boa Sorte & Divirta-se!!"
 
 // Knife Round
 "^4[%s]^1 Knife Round: The ^3winner chooses the starting team."
 en:"^4[%s]^1 Knife Round: The ^3winner chooses the starting team."
+ru:"^4[%s]^1 Ножевой раунд: ^3победитель выбирает стартовую сторону."
 br:"^4[%s]^1 Round Faca: O ^3vencedor escolhe o time inicial."
 
 // Pug Mod
 "Dead"
 en:"Dead"
+ru:"Мертв"
 br:"Morto"
 
 "Deathmatch"
 en:"Deathmatch"
+ru:"Deathmatch"
 br:"Deathmatch"
 
 "Vote Map"
 en:"Vote Map"
+ru:"Голосование за карту"
 br:"Escolha do Mapa"
 
 "Vote Team"
 en:"Vote Team"
+ru:"Голосование за команды"
 br:"Escolha do Time"
 
 "Captains"
 en:"Captains"
+ru:"Капитаны"
 br:"Capitães"
 
 "Knife Round"
 en:"Knife Round"
+ru:"Ножевой раунд"
 br:"Round Faca"
 
 "First Half"
 en:"First Half"
+ru:"Первая половина"
 br:"Primeiro Tempo"
 
 "Halftime"
 en:"Halftime"
+ru:"Перерыв"
 br:"Intervalo"
 
 "Second Half"
 en:"Second Half"
+ru:"Вторая половина"
 br:"Segundo Tempo"
 
 "Overtime"
 en:"Overtime"
+ru:"Овертайм"
 br:"Overtime"
 
 "Finished"
 en:"Finished"
+ru:"Завершено"
 br:"Fim"
 
 "^4[%s]^1 ^3%s^1 started: Get ready!!"
 en:"^4[%s]^1 ^3%s^1 started: Get ready!!"
+ru:"^4[%s]^1 Начинается ^3%s^1: готовьтесь!!"
 br:"^4[%s]^1 ^3%s^1 Iniciado: Prepare-se !!"
 
 "^4[%s]^1 Automatically swapping teams."
 en:"^4[%s]^1 Automatically swapping teams."
+ru:"^4[%s]^1 Команды меняются автоматически."
 br:"^4[%s]^1 Trocando times automaticamente."
 
 "Game Over!^nThe ^3%s^1 team surrendered!"
 en:"Game Over!^nThe ^3%s^1 team surrendered!"
+ru:"Игра окончена!^nКоманда ^3%s^1 сдалась!"
 br:"Fim de jogo!^nO time ^3%s^1 se rendeu!"
 
 "^4[%s]^1 Game Over! The ^3%s^1 team surrendered!"
 en:"^4[%s]^1 Game Over! The ^3%s^1 team surrendered!"
+ru:"^4[%s]^1 Игра окончена! Команда ^3%s^1 сдалась!"
 br:"^4[%s]^1 Fim de jogo! O time ^3%s^1 se rendeu!"
 
 "^4[%s]^1 %s Build %s (^3%s^1)"
 en:"^4[%s]^1 %s Build %s (^3%s^1)"
+ru:"^4[%s]^1 %s Build %s (^3%s^1)"
 br:"^4[%s]^1 %s Build %s (^3%s^1)"
 
 "^4[%s]^1 Type ^3%shelp^1 for command list."
 en:"^4[%s]^1 Type ^3%shelp^1 for command list."
+ru:"^4[%s]^1 Введите ^3%shelp^1, чтобы увидеть список команд."
 br:"^4[%s]^1 Digite ^3%shelp^1 para lista de comandos."
 
 "^4[%s]^1 ^3%s^1 left the match."
 en:"^4[%s]^1 ^3%s^1 left the match."
+ru:"^4[%s]^1 ^3%s^1 покинул матч."
 br:"^4[%s]^1 ^3%s^1 Saiu da partida."
 
 "[%s] Round %d Started."
 en:"[%s] Round %d Started."
+ru:"[%s] Раунд %d начался."
 br:"[%s] Round %d Iniciado."
 
 "[%s] Round %d Won By: %s"
 en:"[%s] Round %d Won By: %s"
+ru:"[%s] Раунд %d выигран: %s"
 br:"[%s] Round %d Ganho Por: %s"
 
 "%s^n%s %d : %d %s^nLast Round"
 en:"%s^n%s %d : %d %s^nLast Round"
+ru:"%s^n%s %d : %d %s^nПоследний раунд"
 br:"%s^n%s %d : %d %s^nÚltimo Round"
 
 "%s^n%s %d : %d %s^nMatch End Danger"
 en:"%s^n%s %d : %d %s^nMatch End Danger"
+ru:"%s^n%s %d : %d %s^nОпасность конца матча"
 br:"%s^n%s %d : %d %s^nPerigo Fim da Partida"
 
 "%s^n%s %d : %d %s"
 en:"%s^n%s %d : %d %s"
+ru:"%s^n%s %d : %d %s"
 br:"%s^n%s %d : %d %s"
 
 "End of Game!^n%s %d : %d %s^nThe match ended tied"
 en:"End of Game!^n%s %d : %d %s^nThe match ended tied"
+ru:"Конец игры!^n%s %d : %d %s^nМатч завершился вничью"
 br:"Fim de Jogo!^n%s %d : %d %s^nA partida terminou empatada"
 
 "End of Game!^n%s %d : %d %s^nThe %s won the match"
 en:"End of Game!^n%s %d : %d %s^nThe %s won the match"
+ru:"Конец игры!^n%s %d : %d %s^n%s выиграли матч"
 br:"Fim de Jogo!^n%s %d : %d %s^nOs %s venceram a partida"
 
 "^4[%s]^1 Status: ^3%s^1"
 en:"^4[%s]^1 Status: ^3%s^1"
+ru:"^4[%s]^1 Статус: ^3%s^1"
 br:"^4[%s]^1 Status: ^3%s^1"
 
 "^4[%s]^1 TRs: ^3%d^1, CTs: ^3%d^1, SPECs: ^3%d^1"
 en:"^4[%s]^1 TRs: ^3%d^1, CTs: ^3%d^1, SPECs: ^3%d^1"
+ru:"^4[%s]^1 T: ^3%d^1, CT: ^3%d^1, SPEC: ^3%d^1"
 br:"^4[%s]^1 TRs: ^3%d^1, CTs: ^3%d^1, SPECs: ^3%d^1"
 
 "^4[%s]^1 ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
 en:"^4[%s]^1 ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
+ru:"^4[%s]^1 ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
 br:"^4[%s]^1 ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
 
 "^4[%s]^1 End of game: ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
 en:"^4[%s]^1 End of game: ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
+ru:"^4[%s]^1 Конец игры: ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
 br:"^4[%s]^1 Fim de jogo: ^3%s^1 (^4%d^1) - (^4%d^1) ^3%s^1"
 
 "^4[%s]^1 The ^3%s^1 are winning: %d-%d"
 en:"^4[%s]^1 The ^3%s^1 are winning: %d-%d"
+ru:"^4[%s]^1 ^3%s^1 ведут: %d-%d"
 br:"^4[%s]^1 Os ^3%s^1 estão vencendo: %d-%d"
 
 "^4[%s]^1 End of game! The ^3%s^1 won: %d-%d"
 en:"^4[%s]^1 End of game! The ^3%s^1 won: %d-%d"
+ru:"^4[%s]^1 Конец игры! ^3%s^1 победили: %d-%d"
 br:"^4[%s]^1 Fim de jogo! Os ^3%s^1 venceram: %d-%d"
 
 "^4[%s]^1 Score tied: %d-%d"
 en:"^4[%s]^1 Score tied: %d-%d"
+ru:"^4[%s]^1 Ничья по счету: %d-%d"
 br:"^4[%s]^1 Placar empatado: %d-%d"
 
 "^4[%s]^1 End of game! Score tied: %d-%d"
 en:"^4[%s]^1 End of game! Score tied: %d-%d"
+ru:"^4[%s]^1 Конец игры! Ничья по счету: %d-%d"
 br:"^4[%s]^1 Fim de jogo! Placar empatado: %d-%d"
 
 // Ready System
 "^4[%s]^1 Match starts when ^3%d^1 players are ready."
 en:"^4[%s]^1 Match starts when ^3%d^1 players are ready."
+ru:"^4[%s]^1 Матч начнется, когда готовность подтвердят ^3%d^1 игроков."
 br:"^4[%s]^1 A partida começa quando ^3%d^1 jogadores estiverem prontos."
 
 "^4[%s]^1 All players are ready!"
 en:"^4[%s]^1 All players are ready!"
+ru:"^4[%s]^1 Все игроки готовы!"
 br:"^4[%s]^1 Todos os jogadores estão prontos!"
 
 "^4[%s]^1 When you are ready, type ^3%s^1."
 en:"^4[%s]^1 When you are ready, type ^3%s^1."
+ru:"^4[%s]^1 Когда будете готовы, введите ^3%s^1."
 br:"^4[%s]^1 Quando você estiver pronto, digite ^3%s^1."
 
 "Not Ready (%d of %d):"
 en:"Not Ready (%d of %d):"
+ru:"Не готовы (%d из %d):"
 br:"Aquecendo (%d de %d):"
 
 "Ready (%d of %d):"
 en:"Ready (%d of %d):"
+ru:"Готовы (%d из %d):"
 br:"Pronto (%d de %d):"
 
 "Not Ready: %d / %d^nReady: %d / %d"
 en:"Not Ready: %d / %d^nReady: %d / %d"
+ru:"Не готовы: %d / %d^nГотовы: %d / %d"
 br:"Aquecendo: %d / %d^nPronto: %d / %d"
 
 "^4[%s]^1 ^3%s^1 is ready."
 en:"^4[%s]^1 ^3%s^1 is ready."
+ru:"^4[%s]^1 ^3%s^1 готов."
 br:"^4[%s]^1 ^3%s^1 está pronto."
 
 "^4[%s]^1 You are already ready."
 en:"^4[%s]^1 You are already ready."
+ru:"^4[%s]^1 Вы уже готовы."
 br:"^4[%s]^1 Você já está pronto."
 
 "^4[%s]^1 ^3%s^1 is not ready."
 en:"^4[%s]^1 ^3%s^1 is not ready."
+ru:"^4[%s]^1 ^3%s^1 не готов."
 br:"^4[%s]^1 ^3%s^1 não está pronto."
 
 "^4[%s]^1 You are not ready yet."
 en:"^4[%s]^1 You are not ready yet."
+ru:"^4[%s]^1 Вы еще не готовы."
 br:"^4[%s]^1 Você ainda não está pronto."
 
 // CS:DM Spawn Editor
 "CSDM: Spawn Manager"
 en:"CSDM: Spawn Manager"
+ru:"CSDM: Менеджер спавнов"
 br:"CSDM: Spawn Manager"
 
 "Add Spawn at current position"
 en:"Add Spawn at current position"
+ru:"Добавить спавн в текущей позиции"
 br:"Adicionar Spawn na posição atual"
 
 "Edit Spawn - No Spawn"
 en:"Edit Spawn - No Spawn"
+ru:"Редактировать спавн - спавна нет"
 br:"Editar Spawn - Nenhum Spawn"
 
 "Delete Spawn - No Spawn"
 en:"Delete Spawn - No Spawn"
+ru:"Удалить спавн - спавна нет"
 br:"Apagar Spawn - Nenhum Spawn"
 
 "Edit Spawn - No Spawn Selected"
 en:"Edit Spawn - No Spawn Selected"
+ru:"Редактировать спавн - спавн не выбран"
 br:"Editar Spawn - Nenhum Spawn Marcado"
 
 "Delete Spawn - No Spawn Selected"
 en:"Delete Spawn - No Spawn Selected"
+ru:"Удалить спавн - спавн не выбран"
 br:"Apagar Spawn - Nenhum Spawn Marcado"
 
 "Move nearest Spawn (^yYellow^w) to current position"
 en:"Move nearest Spawn (^yYellow^w) to current position"
+ru:"Переместить ближайший спавн (^yжелтый^w) в текущую позицию"
 br:"Mover Spawn mais próximo (^yAmarelo^w) para a posição atual"
 
 "Delete Spawn - Selected Spawn too far"
 en:"Delete Spawn - Selected Spawn too far"
+ru:"Удалить спавн - выбранный спавн слишком далеко"
 br:"Apagar Spawn - Spawn Selecionado muito longe"
 
 "Delete nearest Spawn"
 en:"Delete nearest Spawn"
+ru:"Удалить ближайший спавн"
 br:"Apagar Spawn mais próximo"
 
 "Select nearest Spawn"
 en:"Select nearest Spawn"
+ru:"Выбрать ближайший спавн"
 br:"Selecionar Spawn mais próximo"
 
 "Show Statistics"
 en:"Show Statistics"
+ru:"Показать статистику"
 br:"Exibir Estatísticas"
 
 "Enable No Clip"
 en:"Enable No Clip"
+ru:"Включить No Clip"
 br:"Ativar No Clip"
 
 "Disable No Clip"
 en:"Disable No Clip"
+ru:"Выключить No Clip"
 br:"Desativar No Clip"
 
 "Discard all changes, and exit"
 en:"Discard all changes, and exit"
+ru:"Отменить все изменения и выйти"
 br:"Descartar todas alterações, e sair"
 
 "Save all changes"
 en:"Save all changes"
+ru:"Сохранить все изменения"
 br:"Salvar todas as alterações"
 
 "Show Stucked Spawns"
 en:"Show Stucked Spawns"
+ru:"Показать застрявшие спавны"
 br:"Mostrar Spawns Presos"
 
 "^4[%s]^1 ^3No-Clip Enabled."
 en:"^4[%s]^1 ^3No-Clip Enabled."
+ru:"^4[%s]^1 ^3No-Clip включен."
 br:"^4[%s]^1 ^3No-Clip Habilitado."
 
 "^4[%s]^1 ^3No-Clip Disabled."
 en:"^4[%s]^1 ^3No-Clip Disabled."
+ru:"^4[%s]^1 ^3No-Clip выключен."
 br:"^4[%s]^1 ^3No-Clip Desabilitado."
 
 "CSDM: Add Spawn Menu"
 en:"CSDM: Add Spawn Menu"
+ru:"CSDM: Меню добавления спавна"
 br:"CSDM: Menu de Adicionar Spawn"
 
 "Add current position as a Random Spawn"
 en:"Add current position as a Random Spawn"
+ru:"Добавить текущую позицию как случайный спавн"
 br:"Adicionar posição atual como um Spawn Aleatório"
 
 "Add current position as a TR Spawn"
 en:"Add current position as a TR Spawn"
+ru:"Добавить текущую позицию как спавн T"
 br:"Adicionar posição atual como um Spawn de TR"
 
 "Add current position as a CT Spawn"
 en:"Add current position as a CT Spawn"
+ru:"Добавить текущую позицию как спавн CT"
 br:"Adicionar posição atual como um Spawn de CT"
 
 "Cancel"
 en:"Cancel"
+ru:"Отмена"
 br:"Cancelar"
 
 "Discard all changes and exit the editor?"
 en:"Discard all changes and exit the editor?"
+ru:"Отменить все изменения и выйти из редактора?"
 br:"Descartar todas as alterações e sair do editor?"
 
 "No, continue editing"
 en:"No, continue editing"
+ru:"Нет, продолжить редактирование"
 br:"Não, continuar editando"
 
 "Yes, discard all and exit the editor"
 en:"Yes, discard all and exit the editor"
+ru:"Да, отменить все и выйти из редактора"
 br:"Sim, descartar tudo e sair do editor"
 
 "^4[%s]^1 ^3Discard all changes and exit the editor?"
 en:"^4[%s]^1 ^3Discard all changes and exit the editor?"
+ru:"^4[%s]^1 ^3Отменить все изменения и выйти из редактора?"
 br:"^4[%s]^1 ^3Descartar todas alterações e sair do editor?"
 
 "^4[%s]^1 All changes have been discarded."
 en:"^4[%s]^1 All changes have been discarded."
+ru:"^4[%s]^1 Все изменения были отменены."
 br:"^4[%s]^1 Todas as alterações foram descartadas."
 
 "^4[%s]^1 Use the command ^3%s^1 to open the editor again."
 en:"^4[%s]^1 Use the command ^3%s^1 to open the editor again."
+ru:"^4[%s]^1 Используйте команду ^3%s^1, чтобы снова открыть редактор."
 br:"^4[%s]^1 Use o comando ^3%s^1. para abrir o editor novamente."
 
 "^4[%s]^1 Nearest spawn: Number ^3%d^1 -> Team ^3%s^1"
 en:"^4[%s]^1 Nearest spawn: Number ^3%d^1 -> Team ^3%s^1"
+ru:"^4[%s]^1 Ближайший спавн: номер ^3%d^1 -> команда ^3%s^1"
 br:"^4[%s]^1 Spawn mais próximo: Número ^3%d^1 -> Time ^3%s^1"
 
 "^4[%s]^1 Origin [%.0f %.0f %.0f] Angle [%.0f %.0f %.0f] VAngle [%.0f %.0f %.0f]"
 en:"^4[%s]^1 Origin [%.0f %.0f %.0f] Angle [%.0f %.0f %.0f] VAngle [%.0f %.0f %.0f]"
+ru:"^4[%s]^1 Origin [%.0f %.0f %.0f] Angle [%.0f %.0f %.0f] VAngle [%.0f %.0f %.0f]"
 br:"^4[%s]^1 Origem [%.0f %.0f %.0f] Ângulo [%.0f %.0f %.0f] VÂngulo [%.0f %.0f %.0f]"
 
 "^4[%s]^1 This spawn (Number ^4%d^1) (Team ^4%s^1) may be stuck: ^3Please fix it."
 en:"^4[%s]^1 This spawn (Number ^4%d^1) (Team ^4%s^1) may be stuck: ^3Please fix it."
+ru:"^4[%s]^1 Этот спавн (номер ^4%d^1) (команда ^4%s^1) может быть застрявшим: ^3исправьте его."
 br:"^4[%s]^1 Esse Spawn (Número ^4%d^1) (Time ^4%s^1) pode estar preso: ^3Faça a correção."
 
 "^4[%s]^1 Spawns: %d; Random: %d; TR: %d; CT: %d"
 en:"^4[%s]^1 Spawns: %d; Random: %d; TR: %d; CT: %d"
+ru:"^4[%s]^1 Спавны: %d; случайные: %d; T: %d; CT: %d"
 br:"^4[%s]^1 Spawns: %d; Aleatório: %d; TR: %d; CT: %d"
 
 "^4[%s]^1 Current Position: X: %.3f Y: %.3f Z: %.3f"
 en:"^4[%s]^1 Current Position: X: %.3f Y: %.3f Z: %.3f"
+ru:"^4[%s]^1 Текущая позиция: X: %.3f Y: %.3f Z: %.3f"
 br:"^4[%s]^1 Posição Atual: X: %.3f Y: %.3f Z: %.3f"
 
 "^4[%s]^1 ^3%u^1 Spawns saved to file: ^3%s.cfg"
 en:"^4[%s]^1 ^3%u^1 Spawns saved to file: ^3%s.cfg"
+ru:"^4[%s]^1 ^3%u^1 спавнов сохранено в файл: ^3%s.cfg"
 br:"^4[%s]^1 ^3%u^1 Spawns salvos no arquivo: ^3%s.cfg"
 
 "^4[%s]^1 Failed to open: ^3%s.cfg"
 en:"^4[%s]^1 Failed to open: ^3%s.cfg"
+ru:"^4[%s]^1 Не удалось открыть: ^3%s.cfg"
 br:"^4[%s]^1 Falha ao abrir: ^3%s.cfg"
 
 "^4[%s]^1 Failed to save file: ^3No Spawn in the list."
 en:"^4[%s]^1 Failed to save file: ^3No Spawn in the list."
+ru:"^4[%s]^1 Не удалось сохранить файл: ^3в списке нет спавнов."
 br:"^4[%s]^1 Falha ao salvar arquivo: ^3Nenhum Spawn na lista."
 
 "^4[%s]^1 ^3No Spawn in the list."
 en:"^4[%s]^1 ^3No Spawn in the list."
+ru:"^4[%s]^1 ^3В списке нет спавнов."
 br:"^4[%s]^1 ^3Nenhum Spawn na lista."
 
 "^4[%s]^1 ^4Good Job! No trapped Spawn were found!"
 en:"^4[%s]^1 ^4Good Job! No trapped Spawn were found!"
+ru:"^4[%s]^1 ^4Отлично! Застрявших спавнов не найдено!"
 br:"^4[%s]^1 ^4Bom Trabalho! Nenhum Spawn preso foi encontrado!"
 
 // Round Stats
 "^4[%s]^1 ^3%s^1 with %d HP (%d AP)"
 en:"^4[%s]^1 ^3%s^1 with %d HP (%d AP)"
+ru:"^4[%s]^1 ^3%s^1 с %d HP (%d AP)"
 br:"^4[%s]^1 ^3%s^1 com %d HP (%d AP)"
 
 "^4[%s]^1 No player alive."
 en:"^4[%s]^1 No player alive."
+ru:"^4[%s]^1 Нет живых игроков."
 br:"^4[%s]^1 Nenhum jogador vivo."
 
 "^4[%s]^1 Hit ^3%s^1 %d time(s) (Damage %d)"
 en:"^4[%s]^1 Hit ^3%s^1 %d time(s) (Damage %d)"
+ru:"^4[%s]^1 Попаданий по ^3%s^1: %d (урон %d)"
 br:"^4[%s]^1 Acertou ^3%s^1 %d vez(es) (Dano %d)"
 
 "^4[%s]^1 No damage this round."
 en:"^4[%s]^1 No damage this round."
+ru:"^4[%s]^1 В этом раунде урона не было."
 br:"^4[%s]^1 Nenhum dano nesse round."
 
 "^4[%s]^1 Damage received from ^3%s^1 %d time(s) (Damage %d)"
 en:"^4[%s]^1 Damage received from ^3%s^1 %d time(s) (Damage %d)"
+ru:"^4[%s]^1 Получено от ^3%s^1: %d попаданий (урон %d)"
 br:"^4[%s]^1 Dano Recebido de ^3%s^1 %d vez(es) (Dano %d)"
 
 "^4[%s]^1 No damage received this round."
 en:"^4[%s]^1 No damage received this round."
+ru:"^4[%s]^1 В этом раунде урон не получен."
 br:"^4[%s]^1 Nenhum dano recebido nesse round."
 
 "^4[%s]^1 (%d dmg | %d hits) to (%d dmg | %d hits) from ^3%s^1 (%d HP)"
 en:"^4[%s]^1 (%d dmg | %d hits) to (%d dmg | %d hits) from ^3%s^1 (%d HP)"
+ru:"^4[%s]^1 (%d урона | %d попаданий) по (%d урона | %d попаданий) от ^3%s^1 (%d HP)"
 br:"^4[%s]^1 (%d dano | %d hits) para (%d dano | %d hits) de ^3%s^1 (%d HP)"
 
 "%s -- %d hit(s) / %d dmg^n"
 en:"%s -- %d acerto(s) / %d dano^n"
+ru:"%s -- %d попад. / %d урона^n"
 br:"%s -- %d hit(s) / %d dmg^n"
 
 "Victims:^n%s"
 en:"Victims:^n%s"
+ru:"Жертвы:^n%s"
 br:"Victims:^n%s"
 
 "^n^n^n^nAttackers:^n%s"
 en:"^n^n^n^nAttackers:^n%s"
+ru:"^n^n^n^nАтакующие:^n%s"
 br:"^n^n^n^nAttackers:^n%s"
 
 // Team Manager
 "^4[%s]^1 Auto selection not allowed."
 en:"^4[%s]^1 Auto selection not allowed."
+ru:"^4[%s]^1 Автовыбор запрещен."
 br:"^4[%s]^1 Seleção automática não permitida."
 
 "^4[%s]^1 Spectators not allowed."
 en:"^4[%s]^1 Spectators not allowed."
+ru:"^4[%s]^1 Наблюдатели запрещены."
 br:"^4[%s]^1 Espectadores não permitidos."
 
 "^4[%s]^1 You are already on team ^3%s^1."
 en:"^4[%s]^1 You are already on team ^3%s^1."
+ru:"^4[%s]^1 Вы уже в команде ^3%s^1."
 br:"^4[%s]^1 Você já está no time ^3%s^1."
 
 "^4[%s]^1 Team switching not allowed during the match."
 en:"^4[%s]^1 Team switching not allowed during the match."
+ru:"^4[%s]^1 Во время матча смена команды запрещена."
 br:"^4[%s]^1 Troca de time não permitida durante a partida."
 
 "^4[%s]^1 Team change by reconnect is not allowed."
 en:"^4[%s]^1 Team change by reconnect is not allowed."
+ru:"^4[%s]^1 Смена команды через переподключение запрещена."
 br:"^4[%s]^1 Trocar de time via reconnect nao é permitido."
 
 "^4[%s]^1 Team ^3%s^1 is already full."
 en:"^4[%s]^1 Team ^3%s^1 is already full."
+ru:"^4[%s]^1 Команда ^3%s^1 уже заполнена."
 br:"^4[%s]^1 O time ^3%s^1 já está completo."
 
 // Timer System
 "^4[%s]^1 Starts when ^3%d^1 players join the game."
 en:"^4[%s]^1 Starts when ^3%d^1 players join the game."
+ru:"^4[%s]^1 Запускается, когда в игру зайдут ^3%d^1 игроков."
 br:"^4[%s]^1 Começa quando ^3%d^1 jogadores entragem no jogo."
 
 "^4[%s]^1 Time's up: ^3All players must be ready!"
 en:"^4[%s]^1 Time's up: ^3All players must be ready!"
+ru:"^4[%s]^1 Время вышло: ^3все игроки должны быть готовы!"
 br:"^4[%s]^1 O tempo acabou: ^3Todos os jogadores devem estar prontos!"
 
 "%s^n%d Players Required"
 en:"%s^n%d Players Required"
+ru:"%s^nТребуется игроков: %d"
 br:"%s^n%d Jogadores Necessários"
 
 "%s^n%d Player Required"
 en:"%s^n%d Player Required"
+ru:"%s^nТребуется игрок: %d"
 br:"%s^n%d Jogador Necessário"
 
 "MATCH STARTING IN^n%M:%S"
 en:"MATCH STARTING IN^n%M:%S"
+ru:"МАТЧ НАЧНЕТСЯ ЧЕРЕЗ^n%M:%S"
 br:"INICIANDO PARTIDA EM^n%M:%S"
 
 // Vote end
 "Continue Match"
 en:"Continue Match"
+ru:"Продолжить матч"
 br:"Continuar Partida"
 
 "Cancel Match"
 en:"Cancel Match"
+ru:"Отменить матч"
 br:"Cancelar Partida"
 
 "Restart Match"
 en:"Restart Match"
+ru:"Перезапустить матч"
 br:"Reiniciar Partida"
 
 "A player left the match, what do you want to do?"
 en:"A player left the match, what do you want to do?"
+ru:"Игрок покинул матч, что вы хотите сделать?"
 br:"Um Jogador saiu da partida, o que deseja fazer?"
 
 "^4[%s]^1 A player left the match, what do you want to do?"
 en:"^4[%s]^1 A player left the match, what do you want to do?"
+ru:"^4[%s]^1 Игрок покинул матч, что вы хотите сделать?"
 br:"^4[%s]^1 Um Jogador saiu da partida, o que deseja fazer?"
 
 "End Match: %s"
 en:"End Match: %s"
+ru:"Завершить матч: %s"
 br:"Finalizar Partida: %s"
 
 "No Votes."
 en:"No Votes."
+ru:"Голосов нет."
 br:"Nenhum voto registrado."
 
 // Vote Map
 "Choose the map:"
 en:"Choose the map:"
+ru:"Выберите карту:"
 br:"Escolha o mapa:"
 
 "^4[%s]^1 Starting new map selection."
 en:"^4[%s]^1 Starting new map selection."
+ru:"^4[%s]^1 Запуск нового голосования за карту."
 br:"^4[%s]^1 Iniciando a escolha do novo mapa."
 
 "^4[%s]^1 Changing map to: ^3%s^1."
 en:"^4[%s]^1 Changing map to: ^3%s^1."
+ru:"^4[%s]^1 Смена карты на: ^3%s^1."
 br:"^4[%s]^1 Alterando mapa para: ^3%s^1."
 
 "^4[%s]^1 Selection failed: No votes."
 en:"^4[%s]^1 Selection failed: No votes."
+ru:"^4[%s]^1 Выбор не удался: нет голосов."
 br:"^4[%s]^1 A escolha falhou: Nenhum voto."
 
 "^4[%s]^1 Restarting map selection."
 en:"^4[%s]^1 Restarting map selection."
+ru:"^4[%s]^1 Перезапуск голосования за карту."
 br:"^4[%s]^1 Reiniciando escolha do mapa."
 
 "^4[%s]^1 The next map will be: ^3%s^1."
 en:"^4[%s]^1 The next map will be: ^3%s^1."
+ru:"^4[%s]^1 Следующая карта: ^3%s^1."
 br:"^4[%s]^1 O Próximo mapa será: ^3%s^1."
 
 "^4[%s]^1 ^3%s^1 chose ^3%s^1."
 en:"^4[%s]^1 ^3%s^1 chose ^3%s^1."
+ru:"^4[%s]^1 ^3%s^1 выбрал ^3%s^1."
 br:"^4[%s]^1 ^3%s^1 escolheu ^3%s^1."
 
 "Map Choice: %s"
 en:"Map Choice: %s"
+ru:"Выбор карты: %s"
 br:"Escolha do Mapa: %s"
 
 "No votes registered."
 en:"No votes registered."
+ru:"Голоса не зарегистрированы."
 br:"Nenhum voto registrado."
 
 // Vote Overtime
 "Sudden Death"
 en:"Sudden Death"
+ru:"Судден-дез"
 br:"Morte Súbita"
 
 "Play Overtime"
 en:"Play Overtime"
+ru:"Играть овертайм"
 br:"Jogar Overtime"
 
 "End Tied"
 en:"End Tied"
+ru:"Завершить вничью"
 br:"Terminar Empatado"
 
 "Match tied, what do you want to do?"
 en:"Match tied, what do you want to do?"
+ru:"Матч завершился вничью, что вы хотите сделать?"
 br:"Partida empatada o que deseja fazer?"
 
 "^4[%s]^1 The match is tied, choose what to do:"
 en:"^4[%s]^1 The match is tied, choose what to do:"
+ru:"^4[%s]^1 Матч завершился вничью, выберите дальнейшее действие:"
 br:"^4[%s]^1 A partida está empatada, escolha o que fazer:"
 
 "^4[%s]^1 1. Sudden Death: ^3The winning team will be the match winner."
 en:"^4[%s]^1 1. Sudden Death: ^3The winning team will be the match winner."
+ru:"^4[%s]^1 1. Судден-дез: ^3выигравшая команда станет победителем матча."
 br:"^4[%s]^1 1. Morte Súbita: ^3O time vencedor será o vencedor da partida."
 
 "^4[%s]^1 2. Play Overtime: ^3The winner will be decided via Overtime."
 en:"^4[%s]^1 2. Play Overtime: ^3The winner will be decided via Overtime."
+ru:"^4[%s]^1 2. Играть овертайм: ^3победитель будет определен в овертайме."
 br:"^4[%s]^1 2. Jogar Overtime: ^3O time vencedor será decidido via Overtime."
 
 "^4[%s]^1 3. End Tied: ^3The match ends without a winner."
 en:"^4[%s]^1 3. End Tied: ^3The match ends without a winner."
+ru:"^4[%s]^1 3. Завершить вничью: ^3матч закончится без победителя."
 br:"^4[%s]^1 3. Terminar Empatado: ^3A partida termina sem um vencedor."
 
 "^4[%s]^1 Continuing match in ^3Sudden Death^1 mode after freezetime."
 en:"^4[%s]^1 Continuing match in ^3Sudden Death^1 mode after freezetime."
+ru:"^4[%s]^1 Матч продолжится в режиме ^3судден-дез^1 после фризтайма."
 br:"^4[%s]^1 Continuando partida no modo ^3Morte Súbita^1 após o freezetime."
 
 "^4[%s]^1 Selection failed: ^3No votes."
 en:"^4[%s]^1 Selection failed: ^3No votes."
+ru:"^4[%s]^1 Выбор не удался: ^3нет голосов."
 br:"^4[%s]^1 A escolha falhou: ^3Nenhum voto."
 
 "^4[%s]^1 ^3%s^1 chose ^3%s^1."
 en:"^4[%s]^1 ^3%s^1 chose ^3%s^1."
+ru:"^4[%s]^1 ^3%s^1 выбрал ^3%s^1."
 br:"^4[%s]^1 ^3%s^1 escolheu ^3%s^1."
 
 "Overtime Mode: %s"
 en:"Overtime Mode: %s"
+ru:"Режим овертайма: %s"
 br:"Modo Overtime: %s"
 
 "No votes registered."
 en:"No votes registered."
+ru:"Голоса не зарегистрированы."
 br:"Nenhum voto registrado."
 
 // Vote Swap Team
 "Terrorists"
 en:"Terrorists"
+ru:"Террористы"
 br:"Terroristas"
 
 "Counter-Terrorists"
 en:"Counter-Terrorists"
+ru:"Контр-террористы"
 br:"Contra-Terroristas"
 
 "Choose the Team:"
 en:"Choose the Team:"
+ru:"Выберите сторону:"
 br:"Escolha o Time:"
 
 "^4[%s]^1 The ^3%s^1 won: Starting team pick."
 en:"^4[%s]^1 The ^3%s^1 won: Starting team pick."
+ru:"^4[%s]^1 Победили ^3%s^1: начинается выбор стартовой стороны."
 br:"^4[%s]^1 Os ^3%s^1 venceram: Iniciando a escolha do time."
 
 "^4[%s]^1 Swapping teams to: ^3%s^1."
 en:"^4[%s]^1 Swapping teams to: ^3%s^1."
+ru:"^4[%s]^1 Смена сторон на: ^3%s^1."
 br:"^4[%s]^1 Trocando times para: ^3%s^1."
 
 "^4[%s]^1 Selection failed: ^3No votes."
 en:"^4[%s]^1 Selection failed: ^3No votes."
+ru:"^4[%s]^1 Выбор не удался: ^3нет голосов."
 br:"^4[%s]^1 A escolha falhou: ^3Nenhum voto."
 
 "^4[%s]^1 ^3%s^1 chose ^3%s^1."
 en:"^4[%s]^1 ^3%s^1 chose ^3%s^1."
+ru:"^4[%s]^1 ^3%s^1 выбрал ^3%s^1."
 br:"^4[%s]^1 ^3%s^1 escolheu ^3%s^1."
 
 "Team Choice: %s"
 en:"Team Choice: %s"
+ru:"Выбор стороны: %s"
 br:"Escolha do Time: %s"
 
 "No votes registered."
 en:"No votes registered."
+ru:"Голоса не зарегистрированы."
 br:"Nenhum voto registrado."
 
 // Vote Team
 "Captains"
 en:"Captains"
+ru:"Капитаны"
 br:"Capitães"
 
 "Shuffle Teams"
 en:"Shuffle Teams"
+ru:"Перемешать команды"
 br:"Misturar Times"
 
 "No Draw"
 en:"No Draw"
+ru:"Оставить команды"
 br:"Sem Sorteio"
 
 "Balance Skill"
 en:"Balance Skill"
+ru:"Баланс по скиллу"
 br:"Balancear Skill"
 
 "Swap Teams"
 en:"Swap Teams"
+ru:"Поменять стороны"
 br:"Trocar Times"
 
 "Knife Round"
 en:"Knife Round"
+ru:"Ножевой раунд"
 br:"Round Faca"
 
 "Game mode:"
 en:"Game mode:"
+ru:"Режим игры:"
 br:"Modo de jogo:"
 
 "^4[%s]^1 Starting team selection."
 en:"^4[%s]^1 Starting team selection."
+ru:"^4[%s]^1 Начинается выбор команд."
 br:"^4[%s]^1 Iniciando a escolha dos times."
 
 "^4[%s]^1 Selection failed: ^3No votes."
 en:"^4[%s]^1 Selection failed: ^3No votes."
+ru:"^4[%s]^1 Выбор не удался: ^3нет голосов."
 br:"^4[%s]^1 A escolha falhou: ^3Nenhum voto."
 
 "^4[%s]^1 Organizing players automatically."
 en:"^4[%s]^1 Organizing players automatically."
+ru:"^4[%s]^1 Игроки распределяются автоматически."
 br:"^4[%s]^1 Organizando os jogadores automaticamente."
 
 "^4[%s]^1 Teams are already set."
 en:"^4[%s]^1 Teams are already set."
+ru:"^4[%s]^1 Команды уже сформированы."
 br:"^4[%s]^1 Os times já estão definidos."
 
 "^4[%s]^1 Organizing players by skill."
 en:"^4[%s]^1 Organizing players by skill."
+ru:"^4[%s]^1 Игроки распределяются по скиллу."
 br:"^4[%s]^1 Organizando os jogadores por skill."
 
 "^4[%s]^1 Switching team sides."
 en:"^4[%s]^1 Switching team sides."
+ru:"^4[%s]^1 Стороны меняются местами."
 br:"^4[%s]^1 Trocando o lado dos times."
 
 "^4[%s]^1 ^3%s^1 chose ^3%s^1."
 en:"^4[%s]^1 ^3%s^1 chose ^3%s^1."
+ru:"^4[%s]^1 ^3%s^1 выбрал ^3%s^1."
 br:"^4[%s]^1 ^3%s^1 escolheu ^3%s^1."
 
 "Team Choice: %s"
 en:"Team Choice: %s"
+ru:"Выбор стороны: %s"
 br:"Escolha dos Times: %s"
 
 "No votes registered."
 en:"No votes registered."
+ru:"Голоса не зарегистрированы."
 br:"Nenhum voto registrado."
 
 // Vote Menu
 "Vote Menu:"
 en:"Vote Menu:"
+ru:"Меню голосования:"
 br:"Menu de votação:"
 
 "Kick Player"
 en:"Kick Player"
+ru:"Кикнуть игрока"
 br:"Kickar Jogador"
 
 "Change Map"
 en:"Change Map"
+ru:"Сменить карту"
 br:"Mudar Mapa"
 
 "Pause Match"
 en:"Pause Match"
+ru:"Поставить матч на паузу"
 br:"Pausar Partida"
 
 "Restart Match"
 en:"Restart Match"
+ru:"Перезапустить матч"
 br:"Reiniciar Partida"
 
 "Cancel Match"
 en:"Cancel Match"
+ru:"Отменить матч"
 br:"Cancelar Partida"
 
 "Vote Surrender"
 en:"Vote Surrender"
+ru:"Голосование за сдачу"
 br:"Votar Rendição"
 
 "^4[%s]^1 Choose an option to vote."
 en:"^4[%s]^1 Choose an option to vote."
+ru:"^4[%s]^1 Выберите вариант для голосования."
 br:"^4[%s]^1 Escolha a opção de voto"
 
 "^4[%s]^1 Command unavailable."
 en:"^4[%s]^1 Command unavailable."
+ru:"^4[%s]^1 Команда недоступна."
 br:"^4[%s]^1 Comando indisponível."
 
 "^4[%s]^1 Vote kick disabled."
 en:"^4[%s]^1 Vote kick disabled."
+ru:"^4[%s]^1 Голосование за кик отключено."
 br:"^4[%s]^1 Vote Kick inativo."
 
 "^4[%s]^1 Vote kick need more than ^3%d^1 players to be used."
 en:"^4[%s]^1 Vote kick need more than ^3%d^1 players to be used."
+ru:"^4[%s]^1 Для голосования за кик нужно как минимум ^3%d^1 игроков."
 br:"^4[%s]^1 O Vote Kick precisa de ^3%d^1 jogadores para ser usado."
 
 "Vote Kick:"
 en:"Vote Kick:"
+ru:"Голосование за кик:"
 br:"Vote Kick:"
 
 "^4[%s]^1 Choose an player to vote kick."
 en:"^4[%s]^1 Choose an player to vote kick."
+ru:"^4[%s]^1 Выберите игрока для голосования за кик."
 br:"^4[%s]^1 Escolha um jogador para kickar."
 
 "^4[%s]^1 Already voted to kick: ^3%s^1."
 en:"^4[%s]^1 Already voted to kick: ^3%s^1."
+ru:"^4[%s]^1 Вы уже голосовали за кик ^3%s^1."
 br:"^4[%s]^1 Você já votou para kickar: ^3%s^1."
 
 "^4[%s]^1 ^3%s^1 voted to kick ^3%s^1: %2.0f%% of votes to kick."
 en:"^4[%s]^1 ^3%s^1 voted to kick ^3%s^1: %2.0f%% of votes to kick."
+ru:"^4[%s]^1 ^3%s^1 проголосовал за кик ^3%s^1: %2.0f%% голосов за кик."
 br:"^4[%s]^1 ^3%s^1 votou para kickar ^3%s^1: %2.0f%% de votos para kickar."
 
 "^4[%s]^1 Say ^3%s^1 to open vote menu."
 en:"^4[%s]^1 Say ^3%s^1 to open vote menu."
+ru:"^4[%s]^1 Напишите ^3%s^1, чтобы открыть меню голосования."
 br:"^4[%s]^1 Digite ^3%s^1 para abrir o menu de votação."
 
 "^4[%s]^1 ^3%s^1 Kicked: ^4%d^1 votes reached."
 en:"^4[%s]^1 ^3%s^1 Kicked: ^4%d^1 votes reached."
+ru:"^4[%s]^1 ^3%s^1 кикнут: достигнуто ^4%d^1 голосов."
 br:"^4[%s]^1 ^3%s^1 Kickado: ^4%d^1 votos alcançados."
 
 "Kicked by Vote Kick."
 en:"Kicked by Vote Kick."
+ru:"Кикнут по результатам голосования."
 br:"Você foi kickado pelo vote kick."
 
 "^4[%s]^1 Vote map disabled."
 en:"^4[%s]^1 Vote map disabled."
+ru:"^4[%s]^1 Голосование за карту отключено."
 br:"^4[%s]^1 Vote map inativo."
 
 "^4[%s]^1 Map list is empty."
 en:"^4[%s]^1 Map list is empty."
+ru:"^4[%s]^1 Список карт пуст."
 br:"^4[%s]^1 A lista de mapas está vazia."
 
 "^4[%s]^1 Vote map unavailable."
 en:"^4[%s]^1 Vote map unavailable."
+ru:"^4[%s]^1 Голосование за карту недоступно."
 br:"^4[%s]^1 O Vote map está indispoinível."
 
 "Vote Map:"
 en:"Vote Map:"
+ru:"Голосование за карту:"
 br:"Vote Map:"
 
 "^4[%s]^1 Already voted to change map to: ^3%s^1."
 en:"^4[%s]^1 Already voted to change map to: ^3%s^1."
+ru:"^4[%s]^1 Вы уже голосовали за смену карты на: ^3%s^1."
 br:"^4[%s]^1 Você já votou no mapa: ^3%s^1."
 
 "^4[%s]^1 Vote map unavailable."
 en:"^4[%s]^1 Vote map unavailable."
+ru:"^4[%s]^1 Голосование за карту недоступно."
 br:"^4[%s]^1 Vote map indisponível."
 
 "^4[%s]^1 ^3%s^1 voted to change map to ^3%s^1: %2.0f%% of votes to change."
 en:"^4[%s]^1 ^3%s^1 voted to change map to ^3%s^1: %2.0f%% of votes to change."
+ru:"^4[%s]^1 ^3%s^1 проголосовал за смену карты на ^3%s^1: %2.0f%% голосов за смену."
 br:"^4[%s]^1 ^3%s^1 votou para mudar o mapa para ^3%s^1: %2.0f%% de votos para mudar."
 
 "^4[%s]^1 ^3%s^1 Changing map to: ^4%s^1, ^4%d^1 votes reached."
 en:"^4[%s]^1 ^3%s^1 Changing map to: ^4%s^1, ^4%d^1 votes reached."
+ru:"^4[%s]^1 ^3%s^1 меняет карту на: ^4%s^1, достигнуто ^4%d^1 голосов."
 br:"^4[%s]^1 ^3%s^1 Alterando mapa para: ^4%s^1, ^4%d^1 votos alcançados."
 
 "^4[%s]^1 Already voted to pause the game."
 en:"^4[%s]^1 Already voted to pause the game."
+ru:"^4[%s]^1 Вы уже голосовали за паузу."
 br:"^4[%s]^1 Você já votou para pausar a partida."
 
 "^4[%s]^1 Vote pause need more than ^3%d^1 players to be used."
 en:"^4[%s]^1 Vote pause need more than ^3%d^1 players to be used."
+ru:"^4[%s]^1 Для голосования за паузу нужно как минимум ^3%d^1 игроков."
 br:"^4[%s]^1 A pausa do jogo precisa de mais de ^3%d^1 jogadores para ser usada."
 
 "^4[%s]^1 ^3%s^1 (^3%s^1) voted to pause match: %2.0f%% of votes to pause."
 en:"^4[%s]^1 ^3%s^1 (^3%s^1) voted to pause match: %2.0f%% of votes to pause."
+ru:"^4[%s]^1 ^3%s^1 (^3%s^1) проголосовал за паузу: %2.0f%% голосов за паузу."
 br:"^4[%s]^1 ^3%s^1 (^3%s^1) votou para pausar a partida: %2.0f%% de votos para pausar."
 
 "^4[%s]^1 Already voted to restart match."
 en:"^4[%s]^1 Already voted to restart match."
+ru:"^4[%s]^1 Вы уже голосовали за рестарт матча."
 br:"^4[%s]^1 Você já votou para reiniciar a partida."
 
 "^4[%s]^1 Vote restart need more than ^3%d^1 players to be used."
 en:"^4[%s]^1 Vote restart need more than ^3%d^1 players to be used."
+ru:"^4[%s]^1 Для голосования за рестарт нужно как минимум ^3%d^1 игроков."
 br:"^4[%s]^1 A votação de restart precisa de ^3%d^1 jogadores para ser usada."
 
 "^4[%s]^1 ^3%s^1 voted to restart match: %2.0f%% of votes to restart."
 en:"^4[%s]^1 ^3%s^1 voted to restart match: %2.0f%% of votes to restart."
+ru:"^4[%s]^1 ^3%s^1 проголосовал за рестарт матча: %2.0f%% голосов за рестарт."
 br:"^4[%s]^1 ^3%s^1 votou para reiniciar a partida: %2.0f%% de votos para reiniciar."
 
 "^4[%s]^1 The match will be restarted."
 en:"^4[%s]^1 The match will be restarted."
+ru:"^4[%s]^1 Матч будет перезапущен."
 br:"^4[%s]^1 A partida será reiniciada."
 
 "^4[%s]^1 Already voted to cancel match."
 en:"^4[%s]^1 Already voted to cancel match."
+ru:"^4[%s]^1 Вы уже голосовали за отмену матча."
 br:"^4[%s]^1 Você já votou para cancelar a partida."
 
 "^4[%s]^1 Vote cancel need more than ^3%d^1 players to be used."
 en:"^4[%s]^1 Vote cancel need more than ^3%d^1 players to be used."
+ru:"^4[%s]^1 Для голосования за отмену нужно как минимум ^3%d^1 игроков."
 br:"^4[%s]^1 A votação para cancelar precisa de mais de ^3%d^1 jogadores para ser usada."
 
 "^4[%s]^1 ^3%s^1 voted to cancel match: %2.0f%% of votes to cancel."
 en:"^4[%s]^1 ^3%s^1 voted to cancel match: %2.0f%% of votes to cancel."
+ru:"^4[%s]^1 ^3%s^1 проголосовал за отмену матча: %2.0f%% голосов за отмену."
 br:"^4[%s]^1 ^3%s^1 votou para cancelar a partida: %2.0f%% de votos para cancelar."
 
 "^4[%s]^1 The match will be cancelled.."
 en:"^4[%s]^1 The match will be cancelled."
+ru:"^4[%s]^1 Матч будет отменен."
 br:"^4[%s]^1 A partida será cancelada."
 
 "^4[%s]^1 You have already voted to surrender for your team."
 en:"^4[%s]^1 You have already voted to surrender for your team."
+ru:"^4[%s]^1 Вы уже голосовали за сдачу своей команды."
 br:"^4[%s]^1 Você já votou pela rendição do seu time."
 
 "^4[%s]^1 The ^3%s^1 team is complete, cannot vote to surrender."
 en:"^4[%s]^1 The ^3%s^1 team is complete, cannot vote to surrender."
+ru:"^4[%s]^1 Команда ^3%s^1 в полном составе, голосование за сдачу недоступно."
 br:"^4[%s]^1 O time ^3%s^1 está completo, não é possível votar rendição."
 
 "^4[%s]^1 ^3%s^1 (^3%s^1) voted to surrender: %2.0f%% of votes to stop match."
 en:"^4[%s]^1 ^3%s^1 (^3%s^1) voted to surrender: %2.0f%% of votes to stop match."
+ru:"^4[%s]^1 ^3%s^1 (^3%s^1) проголосовал за сдачу: %2.0f%% голосов за сдачу."
 br:"^4[%s]^1 ^3%s^1 (^3%s^1) votou para rendição: %2.0f%% de votos para finalizar a partida."
 
 // Pause
 "^4[%s]^1 ^3%s^1 paused match: Game will pause on next round start."
 en:"^4[%s]^1 ^3%s^1 paused match: Game will pause on next round start."
+ru:"^4[%s]^1 ^3%s^1 поставил матч на паузу: игра встанет на паузу в начале следующего раунда."
 br:"^4[%s]^1 ^3%s^1 pausou a partida: O jogo vai pausar no próximo restart."
 
 "^4[%s]^1 Unable to pause match while game is not running."
 en:"^4[%s]^1 Unable to pause match while game is not running."
+ru:"^4[%s]^1 Нельзя поставить матч на паузу, пока игра не идет."
 br:"^4[%s]^1 Impossível pausar a partida se ela não está em execução."
 
 "^4[%s]^1 Pause timeout is not set."
 en:"^4[%s]^1 Pause timeout is not set."
+ru:"^4[%s]^1 Таймаут паузы не задан."
 br:"^4[%s]^1 O tempo de pausa nao foi definido no servidor."
 
 "^4[%s]^1 The ^3%s^1 team paused match: Game will pause on next round start."
 en:"^4[%s]^1 The ^3%s^1 team paused match: Game will pause on next round start."
+ru:"^4[%s]^1 Команда ^3%s^1 поставила матч на паузу: игра встанет на паузу в начале следующего раунда."
 br:"^4[%s]^1 Os ^3%s^1 pausaram a partida: O jogo será pausado no próximo round."
 
 "^4[%s]^1 Match paused: Match will continue in ^3%s^1."
 en:"^4[%s]^1 Match paused: Match will continue in ^3%s^1."
+ru:"^4[%s]^1 Матч на паузе: матч продолжится через ^3%s^1."
 br:"^4[%s]^1 Partida Pausada: O jogo vai continuar em ^3%s^1."
 
 "^4[%s]^1 Match paused by ^3%s^1: Match will continue in ^3%s^1."
 en:"^4[%s]^1 Match paused by ^3%s^1: Match will continue in ^3%s^1."
+ru:"^4[%s]^1 Матч поставлен на паузу командой ^3%s^1: матч продолжится через ^3%s^1."
 br:"^4[%s]^1 Partida pausada por ^3%s^1: O jogo vai continuar em ^3%s^1."
 
 "MATCH IS PAUSED %M:%S^nWAITING TO CONTINUE"
 en:"MATCH IS PAUSED %M:%S^nWAITING TO CONTINUE"
+ru:"МАТЧ НА ПАУЗЕ %M:%S^nОЖИДАНИЕ ПРОДОЛЖЕНИЯ"
 br:"JOGO PAUSADO %M:%S^nRESTANTES PARA CONTINUAR"
 
 "MATCH WILL CONTINUE AFTER FREEZETIME"
 en:"MATCH WILL CONTINUE AFTER FREEZETIME"
+ru:"МАТЧ ПРОДОЛЖИТСЯ ПОСЛЕ ФРИЗТАЙМА"
 br:"A PARTIDA CONTINUA DEPOIS DO FREEZETIME"
 
 "^4[%s]^1 Match will continue after freezetime."
 en:"^4[%s]^1 Match will continue after freezetime."
+ru:"^4[%s]^1 Матч продолжится после фризтайма."
 br:"^4[%s]^1 A partida continuará após o freezetime."
 
 // Rage Ban
 "^4[%s]^1 Player ^3%s^1 has been added to the rage quit. Hee need to back in ^3%d^1 seconds before ban."
 en:"^4[%s]^1 Player ^3%s^1 has been added to the rage quit. Hee need to back in ^3%d^1 seconds before ban."
+ru:"^4[%s]^1 Игрок ^3%s^1 считается покинувшим матч. Он должен вернуться в течение ^3%d^1 секунд, иначе получит бан."
 br:"^4[%s]^1 O Jogador ^3%s^1 abandonou a partida. Ele deve voltar em ^3%d^1 segundos antes de ser banido."
 
 "banid %d %s"
 en:"banid %d %s"
+ru:"banid %d %s"
 br:"banid %d %s"
 
 "wait;wait;writeid;writeip"
 en:"wait;wait;writeid;writeip"
+ru:"wait;wait;writeid;writeip"
 br:"wait;wait;writeid;writeip"
 
 "^4[%s]^1 Player ^3%s^1 was banned duo rage quit after ^3%d^1 seconds."
 en:"^4[%s]^1 Player ^3%s^1 was banned duo rage quit after ^3%d^1 seconds."
+ru:"^4[%s]^1 Игрок ^3%s^1 был забанен за выход из матча после ^3%d^1 секунд."
 br:"^4[%s]^1 O jogador ^3%s^1 foi banido por abandonar a partida depois de ^3%d^1 segundos."


### PR DESCRIPTION
## Summary
- add Russian translations for all entries in \cstrike/addons/pugmod/cfg/language.cfg\
- keep placeholders and formatting tokens intact for PugMod's language parser
- fix the malformed LO3 entry where the \en:\ line was missing

## Notes
- the default server language in \pugmod.cfg\ is still \en\
- this PR only adds the \u\ locale and does not change runtime logic